### PR TITLE
Bump version to 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 1.24.0 (2018-03-06)
+
 * Compatibility with RuboCop v0.53.0. ([@bquorning][])
 * The `Rails/HttpStatus` cop is unavailable if the `rack` gem cannot be loaded. ([@bquorning][])
 * Fix `Rails/HttpStatus` not working with custom HTTP status codes. ([@bquorning][])

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.23.0'.freeze
+      STRING = '1.24.0'.freeze
     end
   end
 end


### PR DESCRIPTION
A new release to fix the compatibility with RuboCop v0.53.0.

Should fix bbatsov/rubocop#5631.