### PR TITLE
Update homepage URL of gemspec

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
     Code style checking for RSpec files.
     A plugin for the RuboCop code style enforcing & linting tool.
   DESCRIPTION
-  spec.homepage = 'http://github.com/backus/rubocop-rspec'
+  spec.homepage = 'https://github.com/rubocop-rspec/rubocop-rspec'
   spec.authors = ['John Backus', 'Ian MacLeod', 'Nils Gemeinhardt']
   spec.email = [
     'johncbackus@gmail.com',


### PR DESCRIPTION
Follow up of #569.

RuboCop RSpec repository has been moved to rubocop-rspec/rubocop-rspec.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.

If you have created a new cop:
* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop includes examples of good and bad code.
* [ ] You have tests for both code that should be reported and code that is good.
