### PR TITLE
Send coverage results to Code Climate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,24 @@ jobs:
             - vendor/bundle
       - run: rake internal_investigation spec
 
+  code-climate:
+    docker:
+      - image: circleci/ruby:2.5
+    steps:
+      - checkout
+      - run: bundle install
+      - run:
+          name: Setup Code Climate test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+      - run:
+          name: Run specs
+          command: |
+            ./cc-test-reporter before-build
+            rake coverage
+            ./cc-test-reporter after-build --exit-code $?
+
 workflows:
   version: 2
   build:
@@ -117,3 +135,4 @@ workflows:
       - ruby-2.5-rubocop:
           requires: [confirm_config]
       - jruby
+      - code-climate

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'codeclimate-test-reporter', '~> 1.0.0'
-  gem 'simplecov',                 '~> 0.12.0', require: false
+  gem 'simplecov', require: false
 end
 
 local_gemfile = 'Gemfile.local'

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Join the chat at https://gitter.im/rubocop-rspec/Lobby](https://badges.gitter.im/rubocop-rspec/Lobby.svg)](https://gitter.im/rubocop-rspec/Lobby)
 [![Gem Version](https://badge.fury.io/rb/rubocop-rspec.svg)](https://rubygems.org/gems/rubocop-rspec)
 [![Build Status](https://secure.travis-ci.org/backus/rubocop-rspec.svg?branch=master)](http://travis-ci.org/backus/rubocop-rspec)
-[![Coverage Status](https://codeclimate.com/github/backus/rubocop-rspec/badges/coverage.svg)](https://codeclimate.com/github/backus/rubocop-rspec/coverage)
-[![Code Climate](https://codeclimate.com/github/backus/rubocop-rspec/badges/gpa.svg)](https://codeclimate.com/github/backus/rubocop-rspec)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/f6254deb61671e357f30/test_coverage)](https://codeclimate.com/github/rubocop-rspec/rubocop-rspec/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/f6254deb61671e357f30/maintainability)](https://codeclimate.com/github/rubocop-rspec/rubocop-rspec/maintainability)
 
 RSpec-specific analysis for your projects, as an extension to
 [RuboCop](https://github.com/bbatsov/rubocop).

--- a/Rakefile
+++ b/Rakefile
@@ -20,8 +20,6 @@ desc 'Run RSpec with code coverage'
 task :coverage do
   ENV['COVERAGE'] = 'true'
   Rake::Task['spec'].execute
-
-  sh('codeclimate-test-reporter') if ENV['CI']
 end
 
 desc 'Run RuboCop over this gem'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'rubocop'
 
 require 'rubocop/rspec/support'
 
-if ENV['CI']
+if ENV['COVERAGE'] == 'true'
   require 'simplecov'
   SimpleCov.start
 end


### PR DESCRIPTION
Fixes #571

Adds one job to the Circle CI configuration, where `rake coverage` is run between `./cc-test-reporter`’s `before-build` and `after-build` commands.

The `codeclimate-test-reporter` gem is not needed anymore, and we can use a more recent version of `simplecov`, too.

I also changed `spec_helper.rb` so that SimpleCov is only run when the the `rake coverage` task is invoked.

Also using the new Code Climate badges in our Readme.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
