### PR TITLE
Increase code coverage

### DIFF
--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -160,14 +160,6 @@ module RuboCop
 
           attr_reader :node, :block, :body
 
-          def range
-            Parser::Source::Range.new(
-              block.source_range.source_buffer,
-              node.source_range.end_pos,
-              block.source_range.end_pos
-            )
-          end
-
           def heredoc?
             body.loc.is_a?(Parser::Source::Map::Heredoc)
           end

--- a/spec/rubocop/cop/rspec/cop_spec.rb
+++ b/spec/rubocop/cop/rspec/cop_spec.rb
@@ -23,10 +23,6 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
     stub_const('RuboCop::RSpec', Module.new)
     # rubocop:disable ClassAndModuleChildren
     class RuboCop::RSpec::FakeCop < described_class
-      def self.name
-        'RuboCop::RSpec::FakeCop'
-      end
-
       def on_send(node)
         add_offense(node, location: :expression, message: 'I flag everything')
       end

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
 
     it 'checks for the use of described class with module' do
-      skip
+      pending
 
       expect_offense(<<-RUBY)
         module MyNamespace

--- a/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
@@ -91,6 +91,10 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher, :config do
                        'expect(foo).to be_a(Array)'
 
       include_examples 'autocorrect',
+                       'expect(foo.instance_of?(Array)).to be_truthy',
+                       'expect(foo).to be_an_instance_of(Array)'
+
+      include_examples 'autocorrect',
                        'expect(foo.has_something?).to be_truthy',
                        'expect(foo).to have_something'
       include_examples 'autocorrect',


### PR DESCRIPTION
Looked at the code coverage report and found 2 methods that could be removed (1 in the specs), one spec example that needed to be added, and one spec that I have marked as `pending` instead of `skip` so that its code is exercised.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
