### PR TITLE
Make SharedExamples work also with explicit receiver

### DIFF
--- a/lib/rubocop/cop/rspec/shared_examples.rb
+++ b/lib/rubocop/cop/rspec/shared_examples.rb
@@ -22,7 +22,9 @@ module RuboCop
       #
       class SharedExamples < Cop
         def_node_matcher :shared_examples, <<-PATTERN
-          (send nil? {#{(SharedGroups::ALL + Includes::ALL).node_pattern}} $sym ...)
+          (send
+            {(const nil? :RSpec) nil?}
+            {#{(SharedGroups::ALL + Includes::ALL).node_pattern}} $sym ...)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/rspec/shared_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_examples_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe RuboCop::Cop::RSpec::SharedExamples do
                       ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
         # ...
       end
+
+      RSpec.shared_examples :foo_bar_baz
+                            ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
     RUBY
   end
 


### PR DESCRIPTION
Shared examples may be defined using e.g. `RSpec.shared_examples`, which wasn’t handled by the cop.

RSpec/SharedExamples hasn’t been released yet, so I haven’t updated the changelog.

cc @anthony-robin 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
