### PR TITLE
Fix false positive when const is being used in a hash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `RSpec/SharedExamples` cop to enforce consistent usage of string to titleize shared examples. ([@anthony-robin][])
 * Add `RSpec/Be` cop to enforce passing argument to the generic `be` matcher. ([@Darhazer][])
+* Fix false positives in `StaticAttributeDefinedDynamically` and `ReturnFromStub` when a const is used in an array or hash. ([@Darhazer][])
 
 ## 1.24.0 (2018-03-06)
 

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -6,6 +6,7 @@ require 'rubocop'
 require_relative 'rubocop/rspec'
 require_relative 'rubocop/rspec/version'
 require_relative 'rubocop/rspec/inject'
+require_relative 'rubocop/rspec/node'
 require_relative 'rubocop/rspec/top_level_describe'
 require_relative 'rubocop/rspec/wording'
 require_relative 'rubocop/rspec/util'
@@ -38,3 +39,5 @@ module RuboCop
     end
   end
 end
+
+RuboCop::AST::Node.include(RuboCop::RSpec::Node)

--- a/lib/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically.rb
@@ -57,7 +57,16 @@ module RuboCop
 
           def static?(attribute)
             value_matcher(attribute).to_a.all? do |node|
-              node.recursive_literal? || node.const_type?
+              recursive_literal?(node)
+            end
+          end
+
+          def recursive_literal?(node)
+            case node.type
+            when :begin, :pair, *AST::Node::COMPOSITE_LITERALS
+              node.children.all? { |child| recursive_literal?(child) }
+            else
+              node.literal? || node.const_type?
             end
           end
 

--- a/lib/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically.rb
@@ -56,18 +56,7 @@ module RuboCop
           private
 
           def static?(attribute)
-            value_matcher(attribute).to_a.all? do |node|
-              recursive_literal?(node)
-            end
-          end
-
-          def recursive_literal?(node)
-            case node.type
-            when :begin, :pair, *AST::Node::COMPOSITE_LITERALS
-              node.children.all? { |child| recursive_literal?(child) }
-            else
-              node.literal? || node.const_type?
-            end
+            value_matcher(attribute).to_a.all?(&:recursive_literal_or_const?)
           end
 
           def value_hash_without_braces?(node)

--- a/lib/rubocop/cop/rspec/factory_bot/static_attribute_defined_dynamically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/static_attribute_defined_dynamically.rb
@@ -41,7 +41,7 @@ module RuboCop
           def on_block(node)
             factory_attributes(node).to_a.flatten.each do |attribute|
               values = block_value_matcher(attribute)
-              next if values.to_a.none? { |v| static?(v) }
+              next if values.to_a.all? { |v| dynamic?(v) }
               add_offense(attribute, location: :expression)
             end
           end
@@ -57,8 +57,8 @@ module RuboCop
 
           private
 
-          def static?(node)
-            node.nil? || node.recursive_literal? || node.const_type?
+          def dynamic?(node)
+            node && !node.recursive_literal_or_const?
           end
 
           def autocorrected_source(node)

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -82,7 +82,7 @@ module RuboCop
 
         def check_block_body(block)
           body = block.body
-          unless body && dynamic?(body) # rubocop:disable Style/GuardClause
+          unless dynamic?(body) # rubocop:disable Style/GuardClause
             add_offense(
               block,
               location: :begin,
@@ -92,16 +92,7 @@ module RuboCop
         end
 
         def dynamic?(node)
-          !recursive_literal?(node)
-        end
-
-        def recursive_literal?(node)
-          case node.type
-          when :begin, :pair, *AST::Node::COMPOSITE_LITERALS
-            node.children.all? { |child| recursive_literal?(child) }
-          else
-            node.literal? || node.const_type?
-          end
+          node && !node.recursive_literal_or_const?
         end
 
         # :nodoc:

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -92,7 +92,16 @@ module RuboCop
         end
 
         def dynamic?(node)
-          !node.recursive_literal? && !node.const_type?
+          !recursive_literal?(node)
+        end
+
+        def recursive_literal?(node)
+          case node.type
+          when :begin, :pair, *AST::Node::COMPOSITE_LITERALS
+            node.children.all? { |child| recursive_literal?(child) }
+          else
+            node.literal? || node.const_type?
+          end
         end
 
         # :nodoc:

--- a/lib/rubocop/rspec/node.rb
+++ b/lib/rubocop/rspec/node.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module RSpec
+    # RuboCop-RSpec specific extensions of RuboCop::AST::Node
+    module Node
+      # In various cops we want to regard const as literal althought it's not
+      # strictly literal.
+      def recursive_literal_or_const?
+        case type
+        when :begin, :pair, *AST::Node::COMPOSITE_LITERALS
+          children.all?(&:recursive_literal_or_const?)
+        else
+          literal? || const_type?
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically_spec.rb
@@ -55,13 +55,23 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::DynamicAttributeDefinedStaticall
               comments_count 0
               title "Static"
               description { FFaker::Lorem.paragraph(10) }
-              tag Tag::MAGIC
               recent_statuses [:published, :draft]
               meta_tags(like_count: 2)
               other_tags({ foo: nil })
 
               before(:create, &:initialize_something)
               after(:create, &:rebuild_cache)
+            end
+          end
+        RUBY
+      end
+
+      it 'accepts const as a static value' do
+        expect_no_offenses(<<-RUBY)
+          #{factory_bot}.define do
+            factory(:post, class: PrivatePost) do
+              tag Tag::MAGIC
+              options({priority: Priotity::HIGH})
             end
           end
         RUBY

--- a/spec/rubocop/cop/rspec/return_from_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/return_from_stub_spec.rb
@@ -62,6 +62,15 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub, :config do
       RUBY
     end
 
+    it 'finds nested constants returned from block' do
+      expect_offense(<<-RUBY)
+        it do
+          allow(Foo).to receive(:bar) { {Life::MEANING => 42} }
+                                      ^ Use `and_return` for static values.
+        end
+      RUBY
+    end
+
     it 'ignores dynamic values returned from block' do
       expect_no_offenses(<<-RUBY)
         it do


### PR DESCRIPTION
const is not a literal so recursive_literal? returns false when there is a const inside.
implemented own version of recursive_literal? that accounts const as a literal.

This fixes #577 

The `recursive_literal?` is now duplicated and we will need to extract it in a helper at some point.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.

If you have created a new cop:
* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop includes examples of good and bad code.
* [ ] You have tests for both code that should be reported and code that is good.
