### PR TITLE
Rspec::NestedGroups cop support --auto-gen-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add `RSpec/Be` cop to enforce passing argument to the generic `be` matcher. ([@Darhazer][])
 * Fix false positives in `StaticAttributeDefinedDynamically` and `ReturnFromStub` when a const is used in an array or hash. ([@Darhazer][])
 * Add `RSpec/Pending` cop to enforce no existing pending or skipped examples.  This is disabled by default. ([@patrickomatic][])
+* Fix `RSpec/NestedGroups` cop support --auto-gen-config. ([@walf443][])
 
 ## 1.24.0 (2018-03-06)
 

--- a/lib/rubocop/cop/rspec/nested_groups.rb
+++ b/lib/rubocop/cop/rspec/nested_groups.rb
@@ -6,6 +6,7 @@ module RuboCop
       # Checks for nested example groups.
       #
       # This cop is configurable using the `Max` option
+      # and supports `--auto-gen-config
       #
       # @example
       #   # bad
@@ -85,6 +86,7 @@ module RuboCop
       #   end
       #
       class NestedGroups < Cop
+        include ConfigurableMax
         include RuboCop::RSpec::TopLevelDescribe
 
         MSG = 'Maximum example group nesting exceeded ' \
@@ -100,6 +102,7 @@ module RuboCop
 
         def on_top_level_describe(node, _args)
           find_nested_contexts(node.parent) do |context, nesting|
+            self.max = nesting
             add_offense(
               context.children.first,
               location: :expression,

--- a/spec/rubocop/cop/rspec/nested_groups_spec.rb
+++ b/spec/rubocop/cop/rspec/nested_groups_spec.rb
@@ -22,6 +22,21 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups, :config do
     RUBY
   end
 
+  it 'support --auto-gen-config' do
+    inspect_source(<<-RUBY, 'spec/foo_spec.rb')
+      describe MyClass do
+        context 'when foo' do
+          context 'when bar' do
+            context 'when baz' do
+            end
+          end
+        end
+      end
+    RUBY
+
+    expect(cop.config_to_allow_offenses).to eq('Max' => 4)
+  end
+
   it 'ignores non-spec context methods' do
     expect_no_offenses(<<-RUBY)
       class MyThingy


### PR DESCRIPTION
Add ` --auto-gen-config` support to the `RSpec::NestedGroups` cop.

Closes #489.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.
