### PR TITLE
Don't check for feature methods outside spec. Fixes #474

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix false positives in `StaticAttributeDefinedDynamically` and `ReturnFromStub` when a const is used in an array or hash. ([@Darhazer][])
 * Add `RSpec/Pending` cop to enforce no existing pending or skipped examples.  This is disabled by default. ([@patrickomatic][])
 * Fix `RSpec/NestedGroups` cop support --auto-gen-config. ([@walf443][])
+* Fix false positives in `Capybara/FeatureMethods` when feature methods are used as property names in a factory. ([@Darhazer][])
 
 ## 1.24.0 (2018-03-06)
 


### PR DESCRIPTION
Since we check not only specs, but factories as well, some cops may give false positives for factories.
The FactoryBot cops check if they are inside a factory, while RSpec and Capybara cops assume to be in a spec. For the specific cop that checks for general usage of some terms that might legally exist in a factory as well, added explicit check for being inside a spec 

cc: @rspeicher 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.

If you have created a new cop:
* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop includes examples of good and bad code.
* [ ] You have tests for both code that should be reported and code that is good.
