### PR TITLE
Fix false positive in  when a sequence has a symbol proc argument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Fix false positive in `RSpec/Pending` cop when pending is used as a method name.  ([@Darhazer][])
+* Fix `FactoryBot/DynamicAttributeDefinedStatically` false positive when using symbol proc argument for a sequence. ([@tdeo][])
 
 ## 1.25.0 (2018-04-07)
 
@@ -330,3 +331,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@jojos003]: https://github.com/jojos003
 [@abrom]: https://github.com/abrom
 [@patrickomatic]: https://github.com/patrickomatic
+[@tdeo]: https://github.com/tdeo

--- a/lib/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically.rb
@@ -31,13 +31,13 @@ module RuboCop
             (block (send nil? {:factory :trait} ...) _ { (begin $...) $(send ...) } )
           PATTERN
 
-          def_node_matcher :callback_with_symbol_proc?, <<-PATTERN
-            (send nil? {:before :after} sym (block_pass sym))
+          def_node_matcher :callback_or_sequence_with_symbol_proc?, <<-PATTERN
+            (send nil? {:before :after :sequence} sym (block_pass sym))
           PATTERN
 
           def on_block(node)
             factory_attributes(node).to_a.flatten.each do |attribute|
-              next if callback_with_symbol_proc?(attribute) ||
+              next if callback_or_sequence_with_symbol_proc?(attribute) ||
                   static?(attribute)
               add_offense(attribute, location: :expression)
             end

--- a/lib/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically.rb
@@ -31,14 +31,9 @@ module RuboCop
             (block (send nil? {:factory :trait} ...) _ { (begin $...) $(send ...) } )
           PATTERN
 
-          def_node_matcher :callback_or_sequence_with_symbol_proc?, <<-PATTERN
-            (send nil? {:before :after :sequence} sym (block_pass sym))
-          PATTERN
-
           def on_block(node)
             factory_attributes(node).to_a.flatten.each do |attribute|
-              next if callback_or_sequence_with_symbol_proc?(attribute) ||
-                  static?(attribute)
+              next if static_or_proc?(attribute)
               add_offense(attribute, location: :expression)
             end
           end
@@ -55,8 +50,10 @@ module RuboCop
 
           private
 
-          def static?(attribute)
-            value_matcher(attribute).to_a.all?(&:recursive_literal_or_const?)
+          def static_or_proc?(attribute)
+            value_matcher(attribute).to_a.all? do |value|
+              value.block_pass_type? || value.recursive_literal_or_const?
+            end
           end
 
           def value_hash_without_braces?(node)

--- a/spec/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/dynamic_attribute_defined_statically_spec.rb
@@ -87,6 +87,16 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::DynamicAttributeDefinedStaticall
         RUBY
       end
 
+      it 'accepts valid sequence definition' do
+        expect_no_offenses(<<-RUBY)
+          #{factory_bot}.define do
+            factory :post do
+              sequence :negative_numbers, &:-@
+            end
+          end
+        RUBY
+      end
+
       bad = <<-RUBY
         #{factory_bot}.define do
           factory :post do


### PR DESCRIPTION
A simple follow-up on https://github.com/rubocop-rspec/rubocop-rspec/pull/562 to handle the same case for sequences.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation (run `rake generate_cops_documentation`).
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.

If you have created a new cop:
* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop includes examples of good and bad code.
* [ ] You have tests for both code that should be reported and code that is good.
