### PR TITLE
Fix false positive in  cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix false positive in `RSpec/Pending` cop when pending is used as a method name.  ([@Darhazer][])
+
 ## 1.25.0 (2018-04-07)
 
 * Add `RSpec/SharedExamples` cop to enforce consistent usage of string to titleize shared examples. ([@anthony-robin][])

--- a/lib/rubocop/cop/rspec/pending.rb
+++ b/lib/rubocop/cop/rspec/pending.rb
@@ -43,8 +43,12 @@ module RuboCop
 
         def_node_matcher :pending_block?, PENDING_EXAMPLES.send_pattern
 
+        def_node_matcher :rspec?, '(send {(const nil? :RSpec) nil?} ...)'
+
         def on_send(node)
           return unless pending_block?(node) || skipped_from_metadata?(node)
+          return unless rspec?(node)
+
           add_offense(node, location: :expression)
         end
 

--- a/spec/rubocop/cop/rspec/pending_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_spec.rb
@@ -106,6 +106,14 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
     RUBY
   end
 
+  it 'flags pending examples when receiver is explicit' do
+    expect_offense(<<-RUBY)
+      RSpec.xit 'test' do
+      ^^^^^^^^^^^^^^^^ Pending spec found.
+      end
+    RUBY
+  end
+
   it 'does not flag describe' do
     expect_no_offenses(<<-RUBY)
       describe 'test' do; end
@@ -157,6 +165,12 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   it 'does not flag example_group' do
     expect_no_offenses(<<-RUBY)
       example_group 'test' do; end
+    RUBY
+  end
+
+  it 'does not flag method called pending' do
+    expect_no_offenses(<<-RUBY)
+      subject { Project.pending }
     RUBY
   end
 end


### PR DESCRIPTION
The `send_pattern` in language does not specify receiver. Usually the receiver must be either `nil?` or `RSpec`. When not-specified, a method named like some of the language methods would trigger false positive.

Fixes #595 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] ~Updated documentation (run `rake generate_cops_documentation`).~
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) is passing.

If you have created a new cop:
* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop includes examples of good and bad code.
* [ ] You have tests for both code that should be reported and code that is good.
