### PR TITLE
Improve contribution guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,41 +1,34 @@
 # Contributing
 
-If you discover issues, have ideas for improvements or new features,
-please report them to the [issue tracker][1] of the repository or
-submit a pull request. Please, try to follow these guidelines when you
-do so.
+If you encounter problems or have ideas for improvements or new features, please report them to the [issue tracker](https://github.com/rubocop-rspec/rubocop-rspec/issues) or submit a pull request. Please, try to follow these guidelines when you do so.
 
 ## Issue reporting
 
 * Check that the issue has not already been reported.
-* Check that the issue has not already been fixed in the latest code
-  (a.k.a. `master`).
+* Check that the issue has not already been fixed in the latest code (a.k.a. `master`).
 * Check if the issue is a non-goal of RuboCop RSpec.
-* Be clear, concise and precise in your description of the problem.
-* Open an issue with a descriptive title and a summary in grammatically correct,
-  complete sentences.
-* Report the versions of `rubocop-rspec`, as well as the output of `rubocop -V`
+* Be clear, concise, and precise in your description of the problem.
+* Open an issue with a descriptive title and a summary in grammatically correct, complete sentences.
+* Report the versions of `rubocop-rspec`, as well as the output of `rubocop -V`.
 * Include any relevant code to the issue summary.
 
 ## Pull requests
-1. Fork the project.
-2. Create a feature branch.
-3. Make sure to add tests.
-4. Make sure the test suite is passing (run `rake`).
-5. Add [Changelog](../blob/master/CHANGELOG.md) entry.
-6. Commit your changes.
-7. Push to the branch.
-8. Create new Pull Request.
+
+1.  Fork the project.
+2.  Create a feature branch.
+3.  Make sure to add tests.
+4.  Make sure the test suite passes (run `rake`).
+5.  Add a [changelog](https://github.com/rubocop-rspec/rubocop-rspec/blob/master/CHANGELOG.md) entry.
+6.  Commit your changes.
+7.  Push to the branch.
+8.  Create new Pull Request.
 
 ## Creating new cops
-There are some steps you have to follow when you add new cops:
-* Add an entry to `config/default.yml`. It's ordered list, make sure to follow the order.
-* The description of the cop in the code should match the one in config. `bin/build_config` copies the description from the cop to config.
-* The cop should include examples of good and bad code.
-* Generate documentation for the cop using `rake generate_cops_documentation`.
-* Add tests for as much use cases as you can think of. Always add tests for both code that should be reported and good code that should pass.
-* Some common pitfalls:
-** If you are writing cop inspecting code outside of an example, check for false positive when similarly named variables are used inside of the example.
-** If your cop is inspecting code inside an example, check that it works when the example is empty (empty `describe`, `it`, etc.).
 
-[1]: https://github.com/backus/rubocop-rspec/issues
+* Document examples of good and bad code in your cop.
+* Add an entry to `config/default.yml`. It's an ordered list, so be sure to insert at the appropriate place.
+* Run `bundle exec rake`. This will verify that the build passes as well as generate documentation and ensure that `config/default.yml` is up to date (don't forget to commit the documentation).
+* Add tests for as many use cases as you can think of. Always add tests for both bad code that should register an offense and good code that should not.
+* Common pitfalls:
+  * If your cop inspects code outside of an example, check for false positives when similarly named variables are used inside of the example.
+  * If your cop inspects code inside of an example, check that it works when the example is empty (empty `describe`, `it`, etc.).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,17 @@
-**Replace this text with a summary of the changes in your PR.
-The more detailed you are, the better.**
+**Replace this text with a summary of the changes in your PR. The more detailed you are, the better.**
 
------------------
+---
 
 Before submitting the PR make sure the following are checked:
 
 * [ ] Feature branch is up-to-date with `master` (if not - rebase it).
 * [ ] Squashed related commits together.
 * [ ] Added tests.
-* [ ] Updated documentation (run `rake generate_cops_documentation`).
-* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
-* [ ] The build (`bundle exec rake`) is passing.
+* [ ] Added an entry to the [changelog](https://github.com/rubocop-rspec/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
+* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
 
 If you have created a new cop:
+
 * [ ] Added the new cop to `config/default.yml`.
-* [ ] The cop includes examples of good and bad code.
-* [ ] You have tests for both code that should be reported and code that is good.
+* [ ] The cop documents examples of good and bad code.
+* [ ] The tests assert both that bad code is reported and that good code is not reported.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 RSpec-specific analysis for your projects, as an extension to
 [RuboCop](https://github.com/bbatsov/rubocop).
 
-
 ## Installation
 
 Just install the `rubocop-rspec` gem
@@ -23,7 +22,6 @@ or if you use bundler put this in your `Gemfile`
 ```
 gem 'rubocop-rspec'
 ```
-
 
 ## Usage
 
@@ -138,10 +136,9 @@ can be achieved using RSpec's `disable_monkey_patching!` method, which you can r
 
 Before disabling `should` you will need all your specs to use the `expect` syntax. You can use [Transpec](http://yujinakayama.me/transpec/), which will do the conversion for you.
 
-
 ## Contributing
 
-Checkout the [contribution guidelines](.github/CONTRIBUTING.md)
+Checkout the [contribution guidelines](.github/CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
I noticed our changelog link was not working in our CONTRIBUTING.md today, and from there I went on to fix a number of other minor issues.

- Fixed broken changelog link in CONTRIBUTING.md. When you are viewing CONTRIBUTING.md, you are already in /blob/ so the extra ../blob/master breaks the link. I decided to just use absolute urls for CONTRIBUTING.md and PULL_REQUEST_TEMPLATE.md to reduce confusion.
- Removed unnecessary line breaks (these were sometimes present after 80 characters, sometimes not--now they are consistently absent), whitespace, etc.
- Fixed a number of grammatical errors
- Improved misc. wording
- Added a reference to `bin/build_config` in PULL_REQUEST_TEMPLATE.md