### PR TITLE
Specify the receiver in Language module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix false positive in `RSpec/EmptyExampleGroup` cop when methods named like a RSpec method are used.  ([@Darhazer][])
+
 ## 1.25.1 (2018-04-10)
 
 * Fix false positive in `RSpec/Pending` cop when pending is used as a method name.  ([@Darhazer][])

--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -39,9 +39,7 @@ module RuboCop
             (sym {:request :feature :system :routing :view}))
         PATTERN
 
-        def_node_matcher :shared_group?, <<-PATTERN
-          (block (send {(const nil? :RSpec) nil?} #{SharedGroups::ALL.node_pattern_union} ...) ...)
-        PATTERN
+        def_node_matcher :shared_group?, SharedGroups::ALL.block_pattern
 
         def on_top_level_describe(node, args)
           return if shared_group?(root_node)

--- a/lib/rubocop/cop/rspec/message_chain.rb
+++ b/lib/rubocop/cop/rspec/message_chain.rb
@@ -14,7 +14,9 @@ module RuboCop
       class MessageChain < Cop
         MSG = 'Avoid stubbing using `%<method>s`.'.freeze
 
-        def_node_matcher :message_chain, Matchers::MESSAGE_CHAIN.send_pattern
+        def_node_matcher :message_chain, <<-PATTERN
+          (send _ {:receive_message_chain :stub_chain} ...)
+        PATTERN
 
         def on_send(node)
           message_chain(node) { add_offense(node, location: :selector) }

--- a/lib/rubocop/cop/rspec/single_argument_message_chain.rb
+++ b/lib/rubocop/cop/rspec/single_argument_message_chain.rb
@@ -19,7 +19,7 @@ module RuboCop
               '`%<called>s` with a single argument.'.freeze
 
         def_node_matcher :message_chain, <<-PATTERN
-          (send _ #{Matchers::MESSAGE_CHAIN.node_pattern_union} $_)
+          (send _ {:receive_message_chain :stub_chain} $_)
         PATTERN
 
         def_node_matcher :single_key_hash?, '(hash pair)'

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -27,7 +27,7 @@ module RuboCop
         end
 
         def send_pattern
-          "(send _ #{node_pattern_union} ...)"
+          "(send {(const nil? :RSpec) nil?} #{node_pattern_union} ...)"
         end
 
         def node_pattern_union
@@ -41,10 +41,6 @@ module RuboCop
         protected
 
         attr_reader :selectors
-      end
-
-      module Matchers
-        MESSAGE_CHAIN = SelectorSet.new(%i[receive_message_chain stub_chain])
       end
 
       module ExampleGroups

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -49,6 +49,20 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
     RUBY
   end
 
+  it 'does not flag methods matching example group names' do
+    expect_no_offenses(<<-RUBY)
+      describe Foo do
+        it 'yields a block when given' do
+          value = nil
+
+          helper.feature('whatevs') { value = 5 }
+
+          expect(value).to be 5
+        end
+      end
+    RUBY
+  end
+
   it 'does not recognize custom include methods by default' do
     expect_offense(<<-RUBY)
       describe Foo do

--- a/spec/rubocop/rspec/language/selector_set_spec.rb
+++ b/spec/rubocop/rspec/language/selector_set_spec.rb
@@ -35,14 +35,16 @@ RSpec.describe RuboCop::RSpec::Language::SelectorSet do
 
   describe '#send_pattern' do
     it 'builds a send matching pattern' do
-      expect(selector_set.send_pattern).to eql('(send _ {:foo :bar} ...)')
+      expect(selector_set.send_pattern).to eql(
+        '(send {(const nil? :RSpec) nil?} {:foo :bar} ...)'
+      )
     end
   end
 
   describe '#block_pattern' do
     it 'builds a block matching pattern' do
       expect(selector_set.block_pattern).to eql(
-        '(block (send _ {:foo :bar} ...) ...)'
+        '(block (send {(const nil? :RSpec) nil?} {:foo :bar} ...) ...)'
       )
     end
   end


### PR DESCRIPTION
We have few false positives in the past because the `Language` module uses a wildcard receiver. #602 is a recent example of this. Now the `Language` module uses a specific receiver (either implicit receiver or explicit RSpec receiver), which will reduce the number of false positives. Some methods do operate on other receivers (like message chain) so I've added an option to use the wildcard receiver (based on rubocop-rspec tests, only message_chain needed this).

This also allows to simplify some matchers where we were specifying the receiver, probably fighting such false positives.

Fixes #602 

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-rspec/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
