### PR TITLE
Fix Capybara/FeatureMethods not working when there is require before the spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Fix false positive in `RSpec/EmptyExampleGroup` cop when methods named like a RSpec method are used.  ([@Darhazer][])
+* Fix `Capybara/FeatureMethods` not working when there is require before the spec. ([@Darhazer][])
 
 ## 1.25.1 (2018-04-10)
 

--- a/lib/rubocop/cop/rspec/capybara/feature_methods.rb
+++ b/lib/rubocop/cop/rspec/capybara/feature_methods.rb
@@ -66,7 +66,7 @@ module RuboCop
           PATTERN
 
           def on_block(node)
-            return unless spec?(root_node)
+            return unless inside_spec?(node)
 
             feature_method(node) do |send_node, match|
               next if enabled?(match)
@@ -87,8 +87,19 @@ module RuboCop
 
           private
 
-          def root_node
-            processed_source.ast
+          def inside_spec?(node)
+            return spec?(node) if root_node?(node)
+
+            root = node.ancestors.find { |parent| root_node?(parent) }
+            spec?(root)
+          end
+
+          def root_node?(node)
+            node.parent.nil? || root_with_siblings?(node.parent)
+          end
+
+          def root_with_siblings?(node)
+            node.begin_type? && node.parent.nil?
           end
 
           def enabled?(method_name)

--- a/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
@@ -76,6 +76,15 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods, :config do
     RUBY
   end
 
+  it 'allows includes before the spec' do
+    expect_offense(<<-RUBY)
+      require 'rails_helper'
+
+      RSpec.feature 'Foo' do; end
+            ^^^^^^^ Use `describe` instead of `feature`.
+    RUBY
+  end
+
   context 'with configured `EnabledMethods`' do
     let(:cop_config) { { 'EnabledMethods' => %w[feature] } }
 


### PR DESCRIPTION
As reported in 75baab383d3d60d0972b3d8e30bc88891bb1c2b0 the cop doesn't work when describe/feature is not the first statement in the file

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-rspec/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
