### PR TITLE
Fix investigation of empty files

### DIFF
--- a/lib/rubocop/cop/rspec/align_left_let_brace.rb
+++ b/lib/rubocop/cop/rspec/align_left_let_brace.rb
@@ -25,6 +25,8 @@ module RuboCop
         end
 
         def investigate(_processed_source)
+          return if processed_source.blank?
+
           token_aligner.offending_tokens.each do |let|
             add_offense(let, location: :begin)
           end

--- a/lib/rubocop/cop/rspec/align_right_let_brace.rb
+++ b/lib/rubocop/cop/rspec/align_right_let_brace.rb
@@ -25,6 +25,8 @@ module RuboCop
         end
 
         def investigate(_processed_source)
+          return if processed_source.blank?
+
           token_aligner.offending_tokens.each do |let|
             add_offense(let, location: :end)
           end

--- a/spec/rubocop/cop/rspec/align_left_let_brace_spec.rb
+++ b/spec/rubocop/cop/rspec/align_left_let_brace_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe RuboCop::Cop::RSpec::AlignLeftLetBrace do
     RUBY
   end
 
+  it 'works with empty file' do
+    expect_no_offenses('')
+  end
+
   offensive_source = <<-RUBY
     let(:foo) { bar }
     let(:hi) { baz }

--- a/spec/rubocop/cop/rspec/align_right_let_brace_spec.rb
+++ b/spec/rubocop/cop/rspec/align_right_let_brace_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe RuboCop::Cop::RSpec::AlignRightLetBrace do
     RUBY
   end
 
+  it 'works with empty file' do
+    expect_no_offenses('')
+  end
+
   offensive_source = <<-RUBY
     let(:foo)      { a }
     let(:hi)       { ab }


### PR DESCRIPTION
References #613
Fixes the following error
```
undefined method `each_node' for nil:NilClass
     # ./lib/rubocop/rspec/align_let_brace.rb:56:in `single_line_lets'
```
---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-rspec/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
