### PR TITLE
Fix OverwritingSetup raising an error for unnamed subject

### DIFF
--- a/lib/rubocop/cop/rspec/overwriting_setup.rb
+++ b/lib/rubocop/cop/rspec/overwriting_setup.rb
@@ -45,10 +45,15 @@ module RuboCop
         def find_duplicates(node)
           setup_expressions = Set.new
           node.each_child_node do |child|
-            setup?(child) do
-              name = one(child.send_node.arguments).value
-              yield child, name unless setup_expressions.add?(name)
-            end
+            next unless setup?(child)
+
+            name = if child.send_node.arguments?
+                     child.send_node.first_argument.value
+                   else
+                     :subject
+                   end
+
+            yield child, name unless setup_expressions.add?(name)
           end
         end
       end

--- a/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
@@ -22,6 +22,17 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
     RUBY
   end
 
+  it 'works with `subject!` and `let!`' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        subject!(:a) { a }
+
+        let!(:a) { b }
+        ^^^^^^^^^^^^^^ `a` is already defined.
+      end
+    RUBY
+  end
+
   it 'finds `let!` overwriting `let`' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
@@ -40,6 +51,17 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
         context `different` do
           let(:a) { b }
         end
+      end
+    RUBY
+  end
+
+  it 'handles unnamed subjects' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        subject { a }
+
+        let(:subject) { b }
+        ^^^^^^^^^^^^^^^^^^^ `subject` is already defined.
       end
     RUBY
   end


### PR DESCRIPTION
57820a1c introduced an error for which there was no test case - handling unnamed subjects

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] ~Added an entry to the [changelog](https://github.com/rubocop-rspec/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.~
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
